### PR TITLE
Fix k8s configuration

### DIFF
--- a/k8s/deployment/nginx-deployment.yaml
+++ b/k8s/deployment/nginx-deployment.yaml
@@ -12,8 +12,8 @@ spec:
       labels:
         app: sample-app
     spec:
-      containers:
-        - name: nginx-container
-          image: nginx:1.12
-          ports:
-            - containerPort: 80
+        containers:
+          - name: nginx-container
+            image: nginx:1.25.3
+            ports:
+              - containerPort: 80

--- a/k8s/service/nodeport-sample.yaml
+++ b/k8s/service/nodeport-sample.yaml
@@ -6,6 +6,7 @@ spec:
   type: NodePort
   ports:
     - name: "http-port"
+      protocol: "TCP"
       port: 80
       targetPort: 80
       nodePort: 30080


### PR DESCRIPTION
## Summary
- update nginx version in `nginx-deployment.yaml`
- add `protocol: "TCP"` to nodeport sample

## Testing
- `python3 -m pip install pyyaml` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a144fcef4832a981c3c2de356b999